### PR TITLE
Initialized Table.df as empty DataFrame

### DIFF
--- a/camelot/core.py
+++ b/camelot/core.py
@@ -339,7 +339,7 @@ class Table:
         self.cols = cols
         self.rows = rows
         self.cells = [[Cell(c[0], r[1], c[1], r[0]) for c in cols] for r in rows]
-        self.df = None
+        self.df = pd.DataFrame()
         self.shape = (0, 0)
         self.accuracy = 0
         self.whitespace = 0


### PR DESCRIPTION
https://github.com/camelot-dev/camelot/pull/344

Here Table.df is initialized as an empty DataFrame instead of None. This is for language servers to understand what members it might contain. For example, in the following line of code,
```
are_table_rows: List[bool] = [True] * table.df.shape[0]
```
Pyright complaints `Cannot access member "shape" for type "None"`. Such misunderstanding would not occur with this commit.



