### PR TITLE
ValueError: min() arg is an empty sequence

### DIFF
--- a/camelot/parsers/stream.py
+++ b/camelot/parsers/stream.py
@@ -96,10 +96,15 @@ class Stream(BaseParser):
             Tuple (x0, y0, x1, y1) in pdf coordinate space.
 
         """
-        xmin = min([t.x0 for direction in t_bbox for t in t_bbox[direction]])
-        ymin = min([t.y0 for direction in t_bbox for t in t_bbox[direction]])
-        xmax = max([t.x1 for direction in t_bbox for t in t_bbox[direction]])
-        ymax = max([t.y1 for direction in t_bbox for t in t_bbox[direction]])
+        xmin = 0
+        ymin = 0
+        xmax = 0
+        ymax = 0
+        if len([t.x0 for direction in t_bbox for t in t_bbox[direction]]) > 0:
+            xmin = min([t.x0 for direction in t_bbox for t in t_bbox[direction]])
+            ymin = min([t.y0 for direction in t_bbox for t in t_bbox[direction]])
+            xmax = max([t.x1 for direction in t_bbox for t in t_bbox[direction]])
+            ymax = max([t.y1 for direction in t_bbox for t in t_bbox[direction]])
         text_bbox = (xmin, ymin, xmax, ymax)
         return text_bbox
 


### PR DESCRIPTION
https://github.com/camelot-dev/camelot/pull/329

Cause: Empty horizontal and vertical dictionaries in t_bbox in method _text_bbox(t_bbox)

Resolution: Added len check condition on t_bbox before updating (xmin, ymin, xmax, ymax) and initialised (xmin, ymin, xmax, ymax) to 0 if len is 0