### PR TITLE
Bugfixes in utils.split_textline, core.Table.to_excel + various linting changes

### DIFF
--- a/camelot/core.py
+++ b/camelot/core.py
@@ -605,14 +605,11 @@ class Table:
             Output filepath.
 
         """
-        kw = {
-            "sheet_name": f"page-{self.page}-table-{self.order}",
-            "encoding": "utf-8",
-        }
+        kw = {"encoding": "utf-8"}
+        sheet_name = f"page-{self.page}-table-{self.order}"
         kw.update(kwargs)
         writer = pd.ExcelWriter(path)
-        self.df.to_excel(writer, **kw)
-        writer.save()
+        self.df.to_excel(writer, sheet_name=sheet_name, **kw)
 
     def to_html(self, path, **kwargs):
         """Writes Table to an HTML file.

--- a/camelot/core.py
+++ b/camelot/core.py
@@ -674,16 +674,16 @@ class TableList:
 
     """
 
-    def __init__(self, tables):
-        self._tables = tables
+    def __init__(self, tables) -> None:
+        self._tables: list[Table] = tables
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"<{self.__class__.__name__} n={self.n}>"
 
-    def __len__(self):
+    def __len__(self) -> int:
         return len(self._tables)
 
-    def __getitem__(self, idx):
+    def __getitem__(self, idx) -> Table:
         return self._tables[idx]
 
     @staticmethod
@@ -691,10 +691,10 @@ class TableList:
         return getattr(table, f"to_{f}")
 
     @property
-    def n(self):
+    def n(self) -> int:
         return len(self)
 
-    def _write_file(self, f=None, **kwargs):
+    def _write_file(self, f=None, **kwargs) -> None:
         dirname = kwargs.get("dirname")
         root = kwargs.get("root")
         ext = kwargs.get("ext")
@@ -704,7 +704,7 @@ class TableList:
             to_format = self._format_func(table, f)
             to_format(filepath)
 
-    def _compress_dir(self, **kwargs):
+    def _compress_dir(self, **kwargs) -> None:
         path = kwargs.get("path")
         dirname = kwargs.get("dirname")
         root = kwargs.get("root")

--- a/camelot/core.py
+++ b/camelot/core.py
@@ -4,6 +4,7 @@ import tempfile
 import zipfile
 from itertools import chain
 from operator import itemgetter
+from typing import Iterator
 
 import numpy as np
 import pandas as pd
@@ -685,6 +686,12 @@ class TableList:
 
     def __getitem__(self, idx) -> Table:
         return self._tables[idx]
+
+    def __iter__(self) -> Iterator[Table]:
+        return iter(self._tables)
+
+    def __next__(self) -> Table:
+        return next(self)
 
     @staticmethod
     def _format_func(table, f):

--- a/camelot/handlers.py
+++ b/camelot/handlers.py
@@ -3,19 +3,19 @@ import sys
 from pathlib import Path
 from typing import Union
 
-from pypdf import PdfReader
-from pypdf import PdfWriter
+from pypdf import PdfReader, PdfWriter
 from pypdf._utils import StrByteType
 
 from .core import TableList
-from .parsers import Lattice
-from .parsers import Stream
-from .utils import TemporaryDirectory
-from .utils import download_url
-from .utils import get_page_layout
-from .utils import get_rotation
-from .utils import get_text_objects
-from .utils import is_url
+from .parsers import Lattice, Stream
+from .utils import (
+    TemporaryDirectory,
+    download_url,
+    get_page_layout,
+    get_rotation,
+    get_text_objects,
+    is_url,
+)
 
 
 class PDFHandler:

--- a/camelot/io.py
+++ b/camelot/io.py
@@ -5,8 +5,7 @@ from typing import Union
 from pypdf._utils import StrByteType
 
 from .handlers import PDFHandler
-from .utils import remove_extra
-from .utils import validate_input
+from .utils import remove_extra, validate_input
 
 
 def read_pdf(

--- a/camelot/parsers/lattice.py
+++ b/camelot/parsers/lattice.py
@@ -10,20 +10,23 @@ import pandas as pd
 
 from ..backends.image_conversion import BACKENDS
 from ..core import Table
-from ..image_processing import adaptive_threshold
-from ..image_processing import find_contours
-from ..image_processing import find_joints
-from ..image_processing import find_lines
-from ..utils import compute_accuracy
-from ..utils import compute_whitespace
-from ..utils import get_table_index
-from ..utils import merge_close_lines
-from ..utils import scale_image
-from ..utils import scale_pdf
-from ..utils import segments_in_bbox
-from ..utils import text_in_bbox
+from ..image_processing import (
+    adaptive_threshold,
+    find_contours,
+    find_joints,
+    find_lines,
+)
+from ..utils import (
+    compute_accuracy,
+    compute_whitespace,
+    get_table_index,
+    merge_close_lines,
+    scale_image,
+    scale_pdf,
+    segments_in_bbox,
+    text_in_bbox,
+)
 from .base import BaseParser
-
 
 logger = logging.getLogger("camelot")
 

--- a/camelot/parsers/lattice.py
+++ b/camelot/parsers/lattice.py
@@ -364,7 +364,7 @@ class Lattice(BaseParser):
                     flag_size=self.flag_size,
                     strip_text=self.strip_text,
                 )
-                if indices[0][:2] != (-1, -1):
+                if len(indices) < 1 or indices[0][:2] != (-1, -1):
                     pos_errors.append(error)
                     indices = Lattice._reduce_index(
                         table, indices, shift_text=self.shift_text

--- a/camelot/utils.py
+++ b/camelot/utils.py
@@ -8,27 +8,23 @@ import warnings
 from itertools import groupby
 from operator import itemgetter
 from urllib.parse import urlparse as parse_url
-from urllib.parse import uses_netloc
-from urllib.parse import uses_params
-from urllib.parse import uses_relative
-from urllib.request import Request
-from urllib.request import urlopen
+from urllib.parse import uses_netloc, uses_params, uses_relative
+from urllib.request import Request, urlopen
 
 import numpy as np
 from pdfminer.converter import PDFPageAggregator
-from pdfminer.layout import LAParams
-from pdfminer.layout import LTAnno
-from pdfminer.layout import LTChar
-from pdfminer.layout import LTImage
-from pdfminer.layout import LTTextLineHorizontal
-from pdfminer.layout import LTTextLineVertical
+from pdfminer.layout import (
+    LAParams,
+    LTAnno,
+    LTChar,
+    LTImage,
+    LTTextLineHorizontal,
+    LTTextLineVertical,
+)
 from pdfminer.pdfdocument import PDFDocument
-from pdfminer.pdfinterp import PDFPageInterpreter
-from pdfminer.pdfinterp import PDFResourceManager
-from pdfminer.pdfpage import PDFPage
-from pdfminer.pdfpage import PDFTextExtractionNotAllowed
+from pdfminer.pdfinterp import PDFPageInterpreter, PDFResourceManager
+from pdfminer.pdfpage import PDFPage, PDFTextExtractionNotAllowed
 from pdfminer.pdfparser import PDFParser
-
 
 _VALID_URLS = set(uses_relative + uses_netloc + uses_params)
 _VALID_URLS.discard("")

--- a/camelot/utils.py
+++ b/camelot/utils.py
@@ -618,7 +618,8 @@ def split_textline(table, textline, direction, flag_size=False, strip_text=""):
                         else:
                             # TODO: add test
                             if cut == x_cuts[-1]:
-                                cut_text.append((r, cut[0] + 1, obj))
+                                new_idx = min(cut[0] + 1, len(table.cols) - 1)
+                                cut_text.append((r, new_idx, obj))
                     elif isinstance(obj, LTAnno):
                         cut_text.append((r, cut[0], obj))
         elif direction == "vertical" and not textline.is_empty():
@@ -651,7 +652,8 @@ def split_textline(table, textline, direction, flag_size=False, strip_text=""):
                         else:
                             # TODO: add test
                             if cut == y_cuts[-1]:
-                                cut_text.append((cut[0] - 1, c, obj))
+                                new_idx = max(cut[0] - 1, 0)
+                                cut_text.append((new_idx, c, obj))
                     elif isinstance(obj, LTAnno):
                         cut_text.append((cut[0], c, obj))
     except IndexError:


### PR DESCRIPTION
Hi there @foarsitter!

First off, thanks for all the work you've done on `camelot-fork`, as well as helping to revive `camelot`. I read through [this issue](https://github.com/camelot-dev/camelot/issues/343) where I saw that you were added a maintainer to the project and are working to merge your changes in from this project to enable Python3.9+ compatibility. With that being said, I've used `camelot-fork` a bit and have noticed some bugs alongside with @josht3. 

This inspired us to create a fork of your fork within our company for internal use, but we figured it would be useful to submit a PR for you to review! Unfortunately, I am unable to provide an example of the bug in action, as I cannot provide you the proprietary PDF and have been unable to re-create it by myself. However, I can try to walk through the changes to the files and describe what they do in theory, and hopefully you will see why this is useful!

1. `core.py`:
  - **`Table.to_excel` method bug-fix:** With the installed version of `pandas` in `camelot-fork`, the `pd.ExcelWriter` object no longer has a `write` method. I've updated this method accordingly to write the file in the recommended manner.
  - **Linting changes:** In my personal usage, I found the type hinting of the original `camelot` package left a lot to be desired. My *personal* use case made the `Table` and `TableList` objects most important, so I've added type hinting to these methods that enable type checkers and linters to provide useful hints when using these objects or functions that return them. For example, I used to get linting errors about iterating through a `TableList`, whereas now I don't! The linter is also able to tell that the objects within the iterable are `Table`s. Just a small QOL change that went a long way in my use-case, and likely will for others.
2. `lattice.py`:
  - **Ensuring `indices` has elements:** This is a small but mighty change! The error I cannot re-create was in this line. After returning from `lattice.get_table_index`, there is no check for whether the `indices` list has any elements. This slight modification does the indices reduction if the `indices` list has no elements.
  - **Import organization:** See below.
4. `utils.py`:
  - **Ensuring `cut_text` elements remain "in bounds" of table in `split_textline`:** The two changes here are for the horizontal and vertical axes within the table. The horizontal change ensures that the maximum cut point is the furthest right column, so it can no longer expand beyond the bounds of the table to the right. The vertical change ensures that the minimum cut point is 0, so it can no longer expand beyond the bounds of the table above it.
  - **Import organization:** See below.
6. `handlers.py`, `io.py`: Just organization of imports. These files were modified automatically by my import sorter. It doesn't particularly hurt or help at all, except maybe improving readability. 